### PR TITLE
Make search field stick to the top of the screen during scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,21 @@
             padding: 1em;
             background-color: #1e1e1e;
         }
+		
+		.search {
+			position: fixed !important;
+			top: 0;
+			width: 100%;
+			padding: 10px;
+			padding-left: 5px;
+			padding-right: 30px;
+			z-index: 100;
+			background-color: #1e1e1e;
+		}
+		
+		.divider {
+			height: 2.5% !important;
+		}
     </style>
 
     <script>
@@ -344,7 +359,7 @@
 </head>
 <body>
 
-<div class="ui fluid input mini">
+<div class="ui fluid input mini search">
     <input id="input" onkeyup="inputKeyupChanged(event)" type="text" placeholder="Search...">
 </div>
 


### PR DESCRIPTION
When using the armory, I often start scrolling and then decide I want to search something. Previously you would then have to scroll back to the top of the page to see the search field, now it always sticks to the top of the page.